### PR TITLE
Allow passing an element-freeing function to hashmap_new

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ int main() {
     // argument is the initial capacity. The third and fourth arguments are 
     // optional seeds that are passed to the following hash function.
     struct hashmap *map = hashmap_new(sizeof(struct user), 0, 0, 0, 
-                                     user_hash, user_compare, NULL);
+                                     user_hash, user_compare, NULL, NULL);
 
     // Here we'll load some users into the hash map. Each set operation
     // performs a copy of the data that is pointed to in the second argument.
@@ -98,6 +98,7 @@ hashmap_count    # returns the number of items in the hash map
 hashmap_set      # insert or replace an existing item and return the previous
 hashmap_get      # get an existing item
 hashmap_delete   # delete and return an item
+hashmap_clear    # clear the hash map
 ```
 
 ### Iteration

--- a/hashmap.h
+++ b/hashmap.h
@@ -17,6 +17,7 @@ struct hashmap *hashmap_new(size_t elsize, size_t cap,
                                              uint64_t seed0, uint64_t seed1),
                             int (*compare)(const void *a, const void *b, 
                                            void *udata),
+                            void (*elfree)(void *item),
                             void *udata);
 struct hashmap *hashmap_new_with_allocator(
                             void *(*malloc)(size_t), 
@@ -28,6 +29,7 @@ struct hashmap *hashmap_new_with_allocator(
                                              uint64_t seed0, uint64_t seed1),
                             int (*compare)(const void *a, const void *b, 
                                            void *udata),
+                            void (*elfree)(void *item),
                             void *udata);
 void hashmap_free(struct hashmap *map);
 void hashmap_clear(struct hashmap *map, bool update_cap);


### PR DESCRIPTION
Thanks for writing `hashmap.c`! It's been a real help.

In one project, I'm using it to store a set of dynamically allocated strings. Freeing the entire map + contents, though, is a bit difficult. Right now, I'm freeing the strings while iterating with `hashmap_scan`, but I can't actually delete them from the map since the internal structure would be resized from underneath the iteration. This leaves me with a map full of hanging pointers.

I figured it'd be helpful if you could specify an arbitrary nullable free'ing function to `hashmap_clear` to deal with situations like these, where elements reference data that should be freed before being removed from the map.