### PR TITLE
Make "key" argument of hashmap_get const void.

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -64,7 +64,7 @@ static void *bucket_item(struct bucket *entry) {
     return ((char*)entry)+sizeof(struct bucket);
 }
 
-static uint64_t get_hash(struct hashmap *map, void *key) {
+static uint64_t get_hash(struct hashmap *map, const void *key) {
     return map->hash(key, map->seed0, map->seed1) << 16 >> 16;
 }
 
@@ -275,7 +275,7 @@ void *hashmap_set(struct hashmap *map, void *item) {
 
 // hashmap_get returns the item based on the provided key. If the item is not
 // found then NULL is returned.
-void *hashmap_get(struct hashmap *map, void *key) {
+void *hashmap_get(struct hashmap *map, const void *key) {
     if (!key) {
         panic("key is null");
     }

--- a/hashmap.h
+++ b/hashmap.h
@@ -33,7 +33,7 @@ void hashmap_free(struct hashmap *map);
 void hashmap_clear(struct hashmap *map, bool update_cap);
 size_t hashmap_count(struct hashmap *map);
 bool hashmap_oom(struct hashmap *map);
-void *hashmap_get(struct hashmap *map, void *item);
+void *hashmap_get(struct hashmap *map, const void *item);
 void *hashmap_set(struct hashmap *map, void *item);
 void *hashmap_delete(struct hashmap *map, void *item);
 void *hashmap_probe(struct hashmap *map, uint64_t position);


### PR DESCRIPTION
FYI I noticed that the argument is called `key` in the source and `item` in the header. Not a real problem, but since `hashmap_set` has `item` in both, I thought it would better to change `key` to `item` in `hashmap_get` for consistency. 