### PR TITLE
Add hashmap_iter function.

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -248,7 +248,7 @@ static bool resize(struct hashmap *map, size_t new_cap) {
 // replaced then it is returned otherwise NULL is returned. This operation
 // may allocate memory. If the system is unable to allocate additional
 // memory then NULL is returned and hashmap_oom() returns true.
-void *hashmap_set(struct hashmap *map, void *item) {
+void *hashmap_set(struct hashmap *map, const void *item) {
     if (!item) {
         panic("item is null");
     }
@@ -418,6 +418,10 @@ bool hashmap_scan(struct hashmap *map,
 // pointer pointer that is populated with the retrieved item. Note that this
 // is NOT a copy of the item stored in the hash map and can be directly
 // modified.
+//
+// Note that if hashmap_delete() is called on the hashmap being iterated,
+// the buckets are rearranged and the iterator must be reset to 0, otherwise
+// unexpected results may be returned after deletion.
 //
 // This function has not been tested for thread safety.
 //

--- a/hashmap.c
+++ b/hashmap.c
@@ -431,7 +431,7 @@ bool hashmap_iter(struct hashmap *map, size_t *i, void **item)
         if (*i >= map->nbuckets) return false;
 
         bucket = bucket_at(map, *i);
-        *i++;
+        (*i)++;
     } while (!bucket->dib);
 
     *item = bucket_item(bucket);

--- a/hashmap.c
+++ b/hashmap.c
@@ -248,7 +248,7 @@ static bool resize(struct hashmap *map, size_t new_cap) {
 // replaced then it is returned otherwise NULL is returned. This operation
 // may allocate memory. If the system is unable to allocate additional
 // memory then NULL is returned and hashmap_oom() returns true.
-void *hashmap_set(struct hashmap *map, const void *item) {
+void *hashmap_set(struct hashmap *map, void *item) {
     if (!item) {
         panic("item is null");
     }

--- a/hashmap.h
+++ b/hashmap.h
@@ -41,6 +41,7 @@ void *hashmap_delete(struct hashmap *map, void *item);
 void *hashmap_probe(struct hashmap *map, uint64_t position);
 bool hashmap_scan(struct hashmap *map,
                   bool (*iter)(const void *item, void *udata), void *udata);
+bool hashmap_iter(struct hashmap *map, size_t *i, void **item);
 
 uint64_t hashmap_sip(const void *data, size_t len, 
                      uint64_t seed0, uint64_t seed1);


### PR DESCRIPTION
This PR adds an alternative iteration method for hash maps. 

Functionally it is identical to hashmap_scan, but it allows to use a `while...do` approach which eliminates the need to define separate functions for simple tasks that are not duplicated in the code base, making the code more readable. 

The testing is very basic, please check for possible flaws. I will implement this in a separate library and report if there are any issues. 