### PR TITLE
Make item in hashmap_set constant.

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -248,7 +248,7 @@ static bool resize(struct hashmap *map, size_t new_cap) {
 // replaced then it is returned otherwise NULL is returned. This operation
 // may allocate memory. If the system is unable to allocate additional
 // memory then NULL is returned and hashmap_oom() returns true.
-void *hashmap_set(struct hashmap *map, void *item) {
+void *hashmap_set(struct hashmap *map, const void *item) {
     if (!item) {
         panic("item is null");
     }

--- a/hashmap.h
+++ b/hashmap.h
@@ -36,7 +36,7 @@ void hashmap_clear(struct hashmap *map, bool update_cap);
 size_t hashmap_count(struct hashmap *map);
 bool hashmap_oom(struct hashmap *map);
 void *hashmap_get(struct hashmap *map, const void *item);
-void *hashmap_set(struct hashmap *map, void *item);
+void *hashmap_set(struct hashmap *map, const void *item);
 void *hashmap_delete(struct hashmap *map, void *item);
 void *hashmap_probe(struct hashmap *map, uint64_t position);
 bool hashmap_scan(struct hashmap *map,


### PR DESCRIPTION
Since items passed hashmap_set are copied into the hash map, it should be safe to make the passed `item` pointer constant. 