### PR TITLE
use hashmap_new_with_allocator instead of hashmap_new in resize()

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -206,9 +206,10 @@ void hashmap_clear(struct hashmap *map, bool update_cap) {
 
 
 static bool resize(struct hashmap *map, size_t new_cap) {
-    struct hashmap *map2 = hashmap_new(map->elsize, new_cap, map->seed1, 
-                                       map->seed1, map->hash, map->compare,
-                                       map->elfree, map->udata);
+    struct hashmap *map2 = hashmap_new_with_allocator(map->malloc, map->realloc, map->free,
+                                                      map->elsize, new_cap, map->seed0, 
+                                                      map->seed1, map->hash, map->compare,
+                                                      map->elfree, map->udata);
     if (!map2) {
         return false;
     }


### PR DESCRIPTION
When resize() kicks in with a hashmap initialized with hashmap_new_with_allocator(), the custom allocators were not being utilized.

Also fix small typo where seed0 was being passed as both seed0 and
seed1 arguments to hashmap_new