### PR TITLE
fix: infinite loop when calling hashmap_set

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -287,6 +287,7 @@ void *hashmap_set(struct hashmap *map, const void *item) {
             memcpy(map->spare, bucket, map->bucketsz);
             memcpy(bucket, entry, map->bucketsz);
             memcpy(entry, map->spare, map->bucketsz);
+            return NULL;
 		}
 		i = (i + 1) & map->mask;
         entry->dib += 1;


### PR DESCRIPTION
when a bucket needs to be extended in size, an infinite loop can occur.

Fixes #29 

Adds `return NULL` after expansion of the bucket in `hashmap_set` on line 289.