### PR TITLE
Modifiy the check condition of same hash bucket in hashmap_set

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -295,7 +295,7 @@ const void *hashmap_set_with_hash(struct hashmap *map, const void *item,
             return NULL;
         }
         bitem = bucket_item(bucket);
-        if (entry->hash == bucket->hash && (!map->compare ||
+        if (entry->dib == bucket->dib && (!map->compare ||
             map->compare(eitem, bitem, map->udata) == 0))
         {
             memcpy(map->spare, bitem, map->elsize);


### PR DESCRIPTION
Hi Tidwall,
I modified the if-condition in `hashmap_set_with_hash` used to check new element-data is same as the bucket_item data or not.
It may be better? I don't known :), just to pull a request to discuss.
Thank you.
